### PR TITLE
fix: book-open icon being rendered

### DIFF
--- a/projects/ion/src/lib/icon/svgs/icons.ts
+++ b/projects/ion/src/lib/icon/svgs/icons.ts
@@ -360,6 +360,7 @@ import {
   change,
   regions,
   imageCheck,
+  bookOpen,
 } from './iconsText';
 
 // To add an icon, use kebab-case on key name and insert only SVG paths on value
@@ -398,6 +399,7 @@ export const iconsPaths: Record<string, string> = {
   'bell-off': bellOff,
   'bell-ringing': bellRinging,
   block,
+  'book-open': bookOpen,
   'box-block': boxBlock,
   'box-clock': boxClock,
   'box-left': boxLeft,


### PR DESCRIPTION
#89 

- before:
The book-open icon was not being rendered.

- after:
![image](https://github.com/Brisanet/ion-plus/assets/138057627/fe90e235-8e97-4ea2-958d-cee62ac1a8f4)
